### PR TITLE
Visualize waypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Vim Editor
 *.swp
+
+#PyCharm
+idea/

--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,4 @@ dmypy.json
 *.swp
 
 #PyCharm
-idea/
+.idea/

--- a/racersim/nodes/racersim_node
+++ b/racersim/nodes/racersim_node
@@ -54,6 +54,7 @@ class RacerSimROS(object):
         self.last_command = None
         self.last_time = None
         self.path = None
+        self.lookahead = [0, 0]
 
         self.frame_id = rospy.get_param('~frame_id', 'map')
         self.timeout = rospy.get_param('~timeout', 1.0) # Seconds
@@ -69,7 +70,8 @@ class RacerSimROS(object):
         # Subscribers
         rospy.Subscriber('bot_velocity_command', Twist, self.command_cb)
         rospy.Subscriber('bot_path', PoseArray, self.pose_arr_cb)
-        
+        rospy.Subscriber('lookahead_pnt', PoseWithCovarianceStamped, self.lookahead_cb)
+
         # Services
         rospy.Service('sim_reset', Empty, self.reset_cb)
 
@@ -92,6 +94,13 @@ class RacerSimROS(object):
     def pose_arr_cb(self, pose_arr_msg):
         """Callback for pose array messages."""
         self.path = pose_arr_msg.poses
+
+    def lookahead_cb(self, pose_msg):
+        """Callback for lookahead_pnt messages."""
+        x = pose_msg.pose.pose.position.x
+        y = pose_msg.pose.pose.position.y
+        self.lookahead = [x, y]
+        #Convert x, y to whatever the sim uses
 
     def command_cb(self, command_msg):
         """Callback for command messages."""
@@ -157,6 +166,9 @@ class RacerSimROS(object):
             goal_msg.pose.pose.orientation.w = goal_quat[0]
             goal_msg.pose.pose.orientation.z = goal_quat[3]
             self.goal_pub.publish(goal_msg)
+
+            #Update the lookahead point
+            self.sim.lookahead = self.lookahead
 
         self.last_time = now
         self.lock.release()

--- a/racersim/nodes/racersim_node
+++ b/racersim/nodes/racersim_node
@@ -55,6 +55,7 @@ class RacerSimROS(object):
         self.last_time = None
         self.path = None
         self.lookahead = [0, 0]
+	self.path_points = [[0,0]]
 
         self.frame_id = rospy.get_param('~frame_id', 'map')
         self.timeout = rospy.get_param('~timeout', 1.0) # Seconds
@@ -94,6 +95,19 @@ class RacerSimROS(object):
     def pose_arr_cb(self, pose_arr_msg):
         """Callback for pose array messages."""
         self.path = pose_arr_msg.poses
+	self.path_points = []
+
+	print('pose_arr_msg.poses')
+	print(pose_arr_msg.poses)
+	print()
+
+	for point in pose_arr_msg.poses:
+		x = point.position.x
+		y = point.position.y
+		self.path_points.append([x, y])
+
+	if self.path_points is None:
+		self.path_points = [[0, 0]]
 
     def lookahead_cb(self, pose_msg):
         """Callback for lookahead_pnt messages."""
@@ -169,6 +183,9 @@ class RacerSimROS(object):
 
             #Update the lookahead point
             self.sim.lookahead = self.lookahead
+
+	    #Update the path points
+	    self.sim.path_points = self.path_points
 
         self.last_time = now
         self.lock.release()

--- a/racersim/src/racersim/renderer.py
+++ b/racersim/src/racersim/renderer.py
@@ -125,7 +125,7 @@ class Renderer(object):
                 self._draw_pnt(pnt, self.SIZE_PNT, self.COLOR_PNT)
 
         #Renders the lookahead point
-        self._visualize_point(self.COLOR_LOOKAHEAD, lookahead, 50)
+        self._visualize_point(self.COLOR_LOOKAHEAD, lookahead, 10)
 
         self._thread = Thread(target=pygame.display.flip)
         self._thread.start()

--- a/racersim/src/racersim/renderer.py
+++ b/racersim/src/racersim/renderer.py
@@ -64,7 +64,6 @@ class Renderer(object):
                     for v in fixture.shape.vertices]
         vertices = [(v[0], self.windowSize - v[1]) \
                     for v in vertices]
-	print('vertices: ' + str(vertices))
         pygame.draw.polygon(self._screen, color, vertices)
 
     def _draw_circle(self, body, fixture, color):
@@ -82,10 +81,8 @@ class Renderer(object):
 
     def _visualize_point(self, color, coords, size):
         for coord in coords:
-	    print('coord: ' + str(coord))
             x = int(-coord[1] * self.scaling)
             y = int(self.windowSize - coord[0] * self.scaling)
-	    print('x: ' + str(x) + ', y: ' + str(y))
             pygame.draw.circle(self._screen, color, [x, y], size)
 
     def render(self, car, ball, goal, world, lookahead, path_points, path=None):

--- a/racersim/src/racersim/renderer.py
+++ b/racersim/src/racersim/renderer.py
@@ -81,12 +81,13 @@ class Renderer(object):
 
     def _visualize_point(self, color, coords, size):
         for coord in coords:
-            x = int(coords[0] * self.scaling)
-            y = int(self.windowSize / 2.0 - coords[1] * self.scaling)
-            #print('lookahead: ' + str([x,y]))
+	    print('coord: ' + str(coord))
+            x = int(coord[0] * self.scaling)
+            y = int(- coord[1] * self.scaling)
+	    print('x: ' + str(x) + ', y: ' + str(y))
             pygame.draw.circle(self._screen, color, [x, y], size)
 
-    def render(self, car, ball, goal, world, lookahead, path=None):
+    def render(self, car, ball, goal, world, lookahead, path_points, path=None):
         """Render the current state of the sim."""
 
         if self._thread is not None and self._thread.is_alive():
@@ -125,7 +126,10 @@ class Renderer(object):
                 self._draw_pnt(pnt, self.SIZE_PNT, self.COLOR_PNT)
 
         #Renders the lookahead point
-        self._visualize_point(self.COLOR_LOOKAHEAD, lookahead, 10)
+        #self._visualize_point(self.COLOR_LOOKAHEAD, [lookahead], 10)
+
+	#Renders the path points
+	self._visualize_point(self.COLOR_PNT, path_points, 10)
 
         self._thread = Thread(target=pygame.display.flip)
         self._thread.start()

--- a/racersim/src/racersim/renderer.py
+++ b/racersim/src/racersim/renderer.py
@@ -64,6 +64,7 @@ class Renderer(object):
                     for v in fixture.shape.vertices]
         vertices = [(v[0], self.windowSize - v[1]) \
                     for v in vertices]
+	print('vertices: ' + str(vertices))
         pygame.draw.polygon(self._screen, color, vertices)
 
     def _draw_circle(self, body, fixture, color):
@@ -82,8 +83,8 @@ class Renderer(object):
     def _visualize_point(self, color, coords, size):
         for coord in coords:
 	    print('coord: ' + str(coord))
-            x = int(coord[0] * self.scaling)
-            y = int(- coord[1] * self.scaling)
+            x = int(-coord[1] * self.scaling)
+            y = int(self.windowSize - coord[0] * self.scaling)
 	    print('x: ' + str(x) + ', y: ' + str(y))
             pygame.draw.circle(self._screen, color, [x, y], size)
 

--- a/racersim/src/racersim/renderer.py
+++ b/racersim/src/racersim/renderer.py
@@ -126,7 +126,7 @@ class Renderer(object):
                 self._draw_pnt(pnt, self.SIZE_PNT, self.COLOR_PNT)
 
         #Renders the lookahead point
-        #self._visualize_point(self.COLOR_LOOKAHEAD, [lookahead], 10)
+        self._visualize_point(self.COLOR_LOOKAHEAD, [lookahead], 10)
 
 	#Renders the path points
 	self._visualize_point(self.COLOR_PNT, path_points, 10)

--- a/racersim/src/racersim/renderer.py
+++ b/racersim/src/racersim/renderer.py
@@ -41,6 +41,7 @@ class Renderer(object):
     COLOR_BALL = (213, 133, 237)        # Purple
     COLOR_WALL = (112, 48, 65)          # Dark-Red
     COLOR_PNT = (245, 173, 66)          # Orange
+    COLOR_LOOKAHEAD = (255, 255, 255)   # White
 
     SIZE_PNT = 20
 
@@ -78,7 +79,14 @@ class Renderer(object):
         """Draws point to the screen."""
         pygame.draw.circle(self._screen, color, pnt, size)
 
-    def render(self, car, ball, goal, world, path=None):
+    def _visualize_point(self, color, coords, size):
+        for coord in coords:
+            x = int(coords[0] * self.scaling)
+            y = int(self.windowSize / 2.0 - coords[1] * self.scaling)
+            #print('lookahead: ' + str([x,y]))
+            pygame.draw.circle(self._screen, color, [x, y], size)
+
+    def render(self, car, ball, goal, world, lookahead, path=None):
         """Render the current state of the sim."""
 
         if self._thread is not None and self._thread.is_alive():
@@ -116,6 +124,8 @@ class Renderer(object):
                 print(pnt)
                 self._draw_pnt(pnt, self.SIZE_PNT, self.COLOR_PNT)
 
+        #Renders the lookahead point
+        self._visualize_point(self.COLOR_LOOKAHEAD, lookahead, 50)
 
         self._thread = Thread(target=pygame.display.flip)
         self._thread.start()

--- a/racersim/src/racersim/sim.py
+++ b/racersim/src/racersim/sim.py
@@ -64,6 +64,7 @@ class Sim(object):
         self.goal = Goal(self.world)
         self.path = None
         self.lookahead = [0, 0]
+	self.path_points = [[0, 0]]
 
         if renderEnabled:
             self.renderer = Renderer(bounds, scaling=scaling)
@@ -109,6 +110,6 @@ class Sim(object):
         """Render the current state of the sim."""
         try:
             self.renderer.render(self.car, self.ball, self.goal, \
-                                 self.world, self.lookahead, path=self.path)
+                                 self.world, self.lookahead, self.path_points, path=self.path)
         except Renderer.ShutdownError:
             self.renderEnabled = False

--- a/racersim/src/racersim/sim.py
+++ b/racersim/src/racersim/sim.py
@@ -63,6 +63,7 @@ class Sim(object):
         self.ball = Ball(self.world)
         self.goal = Goal(self.world)
         self.path = None
+        self.lookahead = [0, 0]
 
         if renderEnabled:
             self.renderer = Renderer(bounds, scaling=scaling)
@@ -108,6 +109,6 @@ class Sim(object):
         """Render the current state of the sim."""
         try:
             self.renderer.render(self.car, self.ball, self.goal, \
-                                 self.world, path=self.path)
+                                 self.world, self.lookahead, path=self.path)
         except Renderer.ShutdownError:
             self.renderEnabled = False


### PR DESCRIPTION
racersim_node will now subscribe to bot_path and lookahead_pnt. The callback function will parse them and pass them to sim.py, which again passes them to renderer.py. Renderer.py will then plot the waypoints (bot_path) and the lookahead_pnt onto the simulator window.

To test this simply use the full_sim.launch provided by Harrison.