### PR TITLE
Chromatags + some Docker stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # ros bags
 *.bag
+
+# VSCode Editor
+.vscode/

--- a/camera_tracking/CMakeLists.txt
+++ b/camera_tracking/CMakeLists.txt
@@ -11,6 +11,12 @@ find_package(catkin REQUIRED COMPONENTS
   camera_aravis
   image_proc
   tf2
+  image_transport
+  cv_bridge
+)
+
+find_package(OpenCV REQUIRED
+  core
 )
 
 ## System dependencies are found with CMake's conventions
@@ -118,6 +124,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -169,6 +176,22 @@ target_link_libraries(${PROJECT_NAME}_tf_parser_node
 )
 target_link_libraries(${PROJECT_NAME}_pose_extractor_node
   ${catkin_LIBRARIES}
+)
+
+add_executable(chromatag_preprocess_node
+  src/chromatag_preprocess_node.cpp
+)
+
+add_dependencies(chromatag_preprocess_node
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+  ${OpenCV_EXPORTED_TARGETS}
+)
+
+# Specify libraries to link a library or executable target against
+target_link_libraries(chromatag_preprocess_node
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 #############

--- a/camera_tracking/src/chromatag_preprocess_node.cpp
+++ b/camera_tracking/src/chromatag_preprocess_node.cpp
@@ -1,0 +1,27 @@
+#include <ros/ros.h>
+#include <image_transport/image_transport.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/core/mat.hpp>
+
+std::unique_ptr<image_transport::Publisher> pub;
+
+void imageCallback(const sensor_msgs::ImageConstPtr& msg) {
+  cv_bridge::CvImagePtr inImg = cv_bridge::toCvCopy(msg, "bgr8");   // convert ROS type to CV type
+  cv:cvCvtColor(&inImg->image, &inImg->image, cv::COLOR_BGR2Lab);   // convert to LAB color space
+  cv_bridge::CvImage outImg{inImg->header, "mono8"};                // create "grayscale" image to fool Apriltags
+  cv::extractChannel(inImg->image, outImg.image, 1);                // extract A channel
+  pub->publish(outImg.toImageMsg());                                // publish
+}
+
+int main(int argc, char* argv[]) {
+  ros::init(argc, argv, "chromatag_preprocess");
+  ros::NodeHandle nh;
+  image_transport::ImageTransport it(nh);
+  image_transport::Subscriber sub = it.subscribe("input", 1, imageCallback);
+  pub = std::make_unique<image_transport::Publisher>(it.advertise("output", 1));
+
+  ros::spin();
+  return 0;
+}

--- a/camera_tracking/src/chromatag_preprocess_node.cpp
+++ b/camera_tracking/src/chromatag_preprocess_node.cpp
@@ -1,26 +1,21 @@
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
-#include <opencv2/opencv.hpp>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/core/mat.hpp>
-
-std::unique_ptr<image_transport::Publisher> pub;
-
-void imageCallback(const sensor_msgs::ImageConstPtr& msg) {
-  cv_bridge::CvImagePtr inImg = cv_bridge::toCvCopy(msg, "bgr8");   // convert ROS type to CV type
-  cv:cvCvtColor(&inImg->image, &inImg->image, cv::COLOR_BGR2Lab);   // convert to LAB color space
-  cv_bridge::CvImage outImg{inImg->header, "mono8"};                // create "grayscale" image to fool Apriltags
-  cv::extractChannel(inImg->image, outImg.image, 1);                // extract A channel
-  pub->publish(outImg.toImageMsg());                                // publish
-}
 
 int main(int argc, char* argv[]) {
   ros::init(argc, argv, "chromatag_preprocess");
   ros::NodeHandle nh;
   image_transport::ImageTransport it(nh);
-  image_transport::Subscriber sub = it.subscribe("input", 1, imageCallback);
-  pub = std::make_unique<image_transport::Publisher>(it.advertise("output", 1));
+  image_transport::Publisher pub = it.advertise("output", 1);
+  image_transport::Subscriber sub = it.subscribe("input", 1,
+    [&pub] (const sensor_msgs::ImageConstPtr& msg) {
+      cv_bridge::CvImagePtr inImg = cv_bridge::toCvCopy(msg, "rgb8");   // convert ROS type to CV type
+      cv:cvtColor(inImg->image, inImg->image, cv::COLOR_RGB2Lab);       // convert to LAB color space
+      cv_bridge::CvImage outImg{inImg->header, "mono8"};                // create "grayscale" image to fool Apriltags
+      cv::extractChannel(inImg->image, outImg.image, 1);                // extract A channel
+      pub.publish(outImg.toImageMsg());                                 // publish
+  });
 
   ros::spin();
   return 0;

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -9,11 +9,10 @@ docker run --rm -it \
     -e USER \
     -e DISPLAY \
     -e NVIDIA_DRIVER_CAPABILITIES=all \
-    -v $XAUTHORITY:/home/$USER/.Xauthority \
+    -v $XAUTHORITY:/home/$USER/.Xauthority:ro \
     -v $WS_DIR:/home/$USER/catkin_ws \
-    -v ~/windows/Downloads:/home/$USER/Downloads \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -v /dev:/dev \
+    -v ~/.gitconfig:/home/$USER/.gitconfig:ro \
     --name $CONTAINER_NAME \
     $@ \
     $REPO_NAME:local \

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -13,6 +13,7 @@ docker run --rm -it \
     -v $WS_DIR:/home/$USER/catkin_ws \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v ~/.gitconfig:/home/$USER/.gitconfig:ro \
+    -v ~/.ssh:/home/$USER/.ssh:ro \
     --name $CONTAINER_NAME \
     $@ \
     $REPO_NAME:local \


### PR DESCRIPTION
Adds a node that can be used to extract the Lab A channel from a color image, and publish it as a grayscale image to fool apriltags. The idea is that doing the preprocessing, while it consumes some CPU, will reduce the amount of data that the Apriltags algorithm needs to process, which can lower overall CPU usage and increase the frequency.

Testing:
This seemed to verify the above concept, but it didn't show any increase in range, which was also advertised.
```
using my webcam at 640x480, 30fps:
- normal apriltags: 110% CPU, 30 fps
- preprocessing + apriltags: (40+70)% CPU, 30 fps

using my webcam at 1920x1080, 30 fps:
- normal apriltags: 300% CPU, 20 fps
- preprocessing + apriltags: (80+140)% CPU, 30 fps
```

Future work:
- test on proper hardware
- clean up our launch files and add this as an option. I don't even know what file I'd add this to