### PR TITLE
simple keyboard interface for testing

### DIFF
--- a/rktl_sim/nodes/keyboard_interface
+++ b/rktl_sim/nodes/keyboard_interface
@@ -2,7 +2,7 @@
 """Use keyboard data to control car in sim.
 License:
   BSD 3-Clause License
-  Copyright (c) 2020, Autonomous Robotics Club of Purdue (Purdue ARC)
+  Copyright (c) 2022, Autonomous Robotics Club of Purdue (Purdue ARC)
   All rights reserved.
 """
 

--- a/rktl_sim/nodes/keyboard_interface
+++ b/rktl_sim/nodes/keyboard_interface
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Use keyboard data to control car in sim.
+License:
+  BSD 3-Clause License
+  Copyright (c) 2020, Autonomous Robotics Club of Purdue (Purdue ARC)
+  All rights reserved.
+"""
+
+import rospy
+from std_msgs.msg import Float32
+from std_srvs.srv import Empty
+
+from curses import wrapper
+from time import sleep
+
+def main(win):
+    win.nodelay(True)
+    throttle_effort = 0
+    steering_effort = 0
+    while not rospy.is_shutdown():
+        key = ""
+        try:
+            key = win.getkey()
+        except:
+            pass
+        if key == 'q':
+            exit()
+        elif key == 'w':
+            throttle_effort += 0.05
+        elif key == 's':
+            throttle_effort -= 0.05
+        elif key == 'a':
+            steering_effort += 0.25
+        elif key == 'd':
+            steering_effort -= 0.25
+        elif key == 'r':
+            reset_srv.call()
+        elif key == 'e':
+            throttle_effort = 0
+            steering_effort = 0
+
+        throttle_effort = max(min(throttle_effort, 1.0), -1.0)
+        steering_effort = max(min(steering_effort, 1.0), -1.0)
+
+        throttle_pub.publish(throttle_effort)
+        steering_pub.publish(steering_effort)
+
+        win.clear()
+        win.addstr("keyboard controller\n")
+        win.addstr("WASD for throttle / steering\n")
+        win.addstr(f"current throttle: {throttle_effort:0.2f}\n")
+        win.addstr(f"current steering: {steering_effort:0.2f}\n")
+        win.addstr("e to reset throttle / steering to zero\n")
+        win.addstr("r to reset sim\n")
+        win.addstr("q to quit")
+        sleep(0.01)
+
+rospy.init_node('keyboard')
+throttle_pub = rospy.Publisher('/effort/throttle', Float32, queue_size=1)
+steering_pub = rospy.Publisher('/effort/steering', Float32, queue_size=1)
+reset_srv = rospy.ServiceProxy('sim_reset', Empty)
+
+wrapper(main)


### PR DESCRIPTION
This is a simple node for using keyboard input to test the sim. Useful since I don't always have an XBOX controller around, and getting to to run on WSL2 isn't worth the effort.

Testing:
```
roslaunch rktl_launch rocket_league_sim.launch
rosrun rktl_sim keyboard_interface
```

All controls are explained in the window.