### PR TITLE
fixed message publication for scoring

### DIFF
--- a/rktl_sim/nodes/simulator_node
+++ b/rktl_sim/nodes/simulator_node
@@ -147,7 +147,10 @@ class SimulatorROS(object):
 
             status = MatchStatus()
             if self.sim.scored:
-                status.status = MatchStatus.VICTORY_TEAM_A
+                if self.sim.winner == "A":
+                    status.status = MatchStatus.VICTORY_TEAM_A
+                elif self.sim.winner == "B":
+                    status.status = MatchStatus.VICTORY_TEAM_B
             else:
                 status.status = MatchStatus.ONGOING
             self.status_pub.publish(status)


### PR DESCRIPTION
Tested by resetting sim until ball collided with both goals. Top goal published a match_status=3, while bottom published a match_status=4, as expected.