### PR TITLE
Training fixes

### DIFF
--- a/rktl_autonomy/src/rktl_autonomy/_ros_interface.py
+++ b/rktl_autonomy/src/rktl_autonomy/_ros_interface.py
@@ -64,7 +64,7 @@ class ROSInterface(Env):
                     with socket.socket() as sock:
                         sock.bind(('localhost', 0))
                         port = sock.getsockname()[1]
-                    time.sleep(random.random(2.0))
+                    time.sleep(2.0*random.random())
             # launch the training ROS network
             ros_id = roslaunch.rlutil.get_or_generate_uuid(None, False)
             roslaunch.configure_logging(ros_id)

--- a/rktl_autonomy/src/rktl_autonomy/_ros_interface.py
+++ b/rktl_autonomy/src/rktl_autonomy/_ros_interface.py
@@ -7,7 +7,7 @@ License:
 
 from abc import abstractmethod
 from threading import Condition
-import time, uuid, socket, os
+import time, uuid, socket, os, random
 
 from gym import Env
 
@@ -64,6 +64,7 @@ class ROSInterface(Env):
                     with socket.socket() as sock:
                         sock.bind(('localhost', 0))
                         port = sock.getsockname()[1]
+                    time.sleep(random.random(2.0))
             # launch the training ROS network
             ros_id = roslaunch.rlutil.get_or_generate_uuid(None, False)
             roslaunch.configure_logging(ros_id)

--- a/rktl_sim/nodes/visualizer_node
+++ b/rktl_sim/nodes/visualizer_node
@@ -135,7 +135,10 @@ class VisualizerROS(object):
         )
 
         while not rospy.is_shutdown():
-            self.window.show()
+            try:
+                self.window.show()
+            except self.window.ShutdownError:
+                exit()
             try:
                 rate.sleep()
             except rospy.ROSInterruptException:


### PR DESCRIPTION
This fixes some things with the new training system. It implements a small wait to help prevent crashes when launching many parallel envs at once. It also makes it so killing the renderer by clicking the red X cleanly exits.