### PR TITLE
Docker zsh hotfix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && \
     DEBIAN_FRONTEND=noninteractive apt upgrade -y && \
     # basics
     DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
-    sudo tmux nano vim git wget net-tools iputils-ping x11-apps htop \
+    sudo tmux nano vim git wget curl net-tools iputils-ping x11-apps htop \
     mesa-utils python3-dev python3-pip python3-tk software-properties-common \
     pylint clang-format jq swig zsh libeigen3-dev python3-catkin-tools && \
     # pip


### PR DESCRIPTION
curl was accidentally removed from the docker image so oh-my-zsh couldn't be installed properly. This adds curl back to the image.