### PR TITLE
Take turns

### DIFF
--- a/rktl_autonomy/src/rktl_autonomy/_ros_interface.py
+++ b/rktl_autonomy/src/rktl_autonomy/_ros_interface.py
@@ -7,7 +7,7 @@ License:
 
 from abc import abstractmethod
 from threading import Condition
-import time, uuid, socket, os, random
+import time, uuid, socket, os
 
 from gym import Env
 
@@ -60,7 +60,7 @@ class ROSInterface(Env):
                     open(f'/tmp/{run_id}_launch', mode='x')
                     break
                 except FileExistsError:
-                    time.sleep(2.0*random.random())
+                    pass
             port = 11311    # default port
             while True:
                 try:


### PR DESCRIPTION
This mitigates timeout issues caused by launching many environments simultaneously by enforcing them to go one at a time. It allows the supercomputer to run many, many envs at once, with the minor downside of launching taking a bit longer.