### PR TITLE
Added option to direct ball at object

### DIFF
--- a/rktl_sim/config/simulation.yaml
+++ b/rktl_sim/config/simulation.yaml
@@ -10,6 +10,7 @@ car:
 
 ball:
   init_speed: 0.0
+  # direct_at_object: 'goalB' # (goalA, goalB, etc.)
   # init_pose:
   #   pos: [0.0, 0.5, 0.06]
   #   orient: [0.0, 0.0, 0.0]

--- a/rktl_sim/nodes/simulator
+++ b/rktl_sim/nodes/simulator
@@ -82,12 +82,14 @@ class SimulatorROS(object):
         # Creating the ball
         ball_init_pose = rospy.get_param('~ball/init_pose', None)
         ball_init_speed = rospy.get_param('~ball/init_speed', None)
+        ball_direct_at_object = rospy.get_param('~ball/direct_at_object', None)
         ball_noise = rospy.get_param('~ball/sensor_noise', None)
         if self.mode == SimulatorMode.IDEAL:
             ball_noise = None
 
         self.sim.create_ball('ball', init_pose=ball_init_pose,
-            init_speed=ball_init_speed, noise=ball_noise)
+            init_speed=ball_init_speed, direct_at_object=ball_direct_at_object,
+            noise=ball_noise)
         
         if self.mode == SimulatorMode.REALISTIC:
             self.ball_pose_pub = rospy.Publisher('/ball/pose_sync_early',

--- a/rktl_sim/src/simulator/sim.py
+++ b/rktl_sim/src/simulator/sim.py
@@ -156,7 +156,7 @@ class Sim(object):
                     0.0,
                 ]
             else:
-                ballVelX = random.Uniform(-self.ball_speed_bound, self.ball_speed_bound)
+                ballVelX = random.uniform(-self.ball_speed_bound, self.ball_speed_bound)
                 ballVel = [
                     ballVelX,
                     math.sqrt(self.ball_speed_bound**2 - ballVelX**2),
@@ -293,7 +293,7 @@ class Sim(object):
                     0.0,
                 ]
             else:
-                ballVelX = random.Uniform(-self.ball_speed_bound, self.ball_speed_bound)
+                ballVelX = random.uniform(-self.ball_speed_bound, self.ball_speed_bound)
                 ballVel = [
                     ballVelX,
                     math.sqrt(self.ball_speed_bound**2 - ballVelX**2),


### PR DESCRIPTION
## Changes

Parameterized ball initial speed direction.

## Testing

Uncomment `direct_at_object` in `simulation.yaml`, then launch sim as per usual.

For `direct_at_object`, you can select any URDF defined in `field_setup`. Can document this more later. Touching this code made me realize that some overall refactoring / documentation is required, but I will introduce this in a future PR to avoid breaking changes.