### PR TITLE
Hyperparam Tuning (script addition and README update)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     pylint clang-format jq swig zsh libeigen3-dev python3-catkin-tools && \
     # pip
     pip3 install --upgrade pip && \
-    pip3 install scipy numpy matplotlib optuna \
+    pip3 install scipy numpy matplotlib \
     pandas jupyterlab autopep8 pyflakes && \
     # Clean Up to reduce image size
     rm -rf /var/lib/apt/lists/* /root/.cache/pip/
@@ -27,7 +27,7 @@ RUN apt update && \
     ros-$ROS_DISTRO-rosserial-arduino \
     ros-$ROS_DISTRO-rosbridge-server && \
     # pip
-    pip3 install pybullet gym[box2d] stable-baselines3 pfilter && \
+    pip3 install pybullet gym[box2d] stable-baselines3 pfilter optuna && \
     # clean up
     rm -rf /var/lib/apt/lists/* /root/.cache/pip/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     pylint clang-format jq swig zsh libeigen3-dev python3-catkin-tools && \
     # pip
     pip3 install --upgrade pip && \
-    pip3 install scipy numpy matplotlib \
+    pip3 install scipy numpy matplotlib optuna \
     pandas jupyterlab autopep8 pyflakes && \
     # Clean Up to reduce image size
     rm -rf /var/lib/apt/lists/* /root/.cache/pip/

--- a/rktl_autonomy/README.md
+++ b/rktl_autonomy/README.md
@@ -239,7 +239,14 @@ docker container kill <name or id>
 ```
 
 ### Hyperparameter Tuning
-To further improve the performance of the network, you can run the `tune_rocket_league.py` script
+To further improve the performance of the network, you can run the `tune_rocket_league.py` script as an executable (`./scripts/tune_rocket_league.py`). 
+
+This script will take the current game settings (rewards, episode length, simulation parameters) as is, and only experiment with hyperparameters of the PPO model. 
+
+These hyperparameters will be fed into the PPO initialization function as `model_params` at the start of each tuning attempt. The choice of hyperparameters is determined by Optuna based on the ranges given in the `optimize_ppo2()` function`. All of the chosen hyperparameter ranges can be modified directly in the function's code.
+
+Within the script, there are also 4 tuning variables that can be modified to change the rate at which the tuning and training-batches occur.
+
 
 ## Real-Time Evaluation
 At this point, you should have trained your network and have a zip file with

--- a/rktl_autonomy/README.md
+++ b/rktl_autonomy/README.md
@@ -238,8 +238,8 @@ discussed above, then use the following command to stop it:
 docker container kill <name or id>
 ```
 
-### Hyperparameter Searching
-TODO
+### Hyperparameter Tuning
+To further improve the performance of the network, you can run the `tune_rocket_league.py` script
 
 ## Real-Time Evaluation
 At this point, you should have trained your network and have a zip file with

--- a/rktl_autonomy/README.md
+++ b/rktl_autonomy/README.md
@@ -247,6 +247,8 @@ These hyperparameters will be fed into the PPO initialization function as `model
 
 Within the script, there are also 4 tuning variables that can be modified to change the rate at which the tuning and training-batches occur.
 
+The tuning script will output progress in the command window it was executed in. Every 5 tuning attempts, it will print out the best hyperparameters that it has found so far. These can later be copied and used in the `train_rocket_league.py` script.
+
 
 ## Real-Time Evaluation
 At this point, you should have trained your network and have a zip file with

--- a/rktl_autonomy/scripts/tune_rocket_league.py
+++ b/rktl_autonomy/scripts/tune_rocket_league.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Training script for the Rocket League project.
+License:
+  BSD 3-Clause License
+  Copyright (c) 2021, Autonomous Robotics Club of Purdue (Purdue ARC)
+  All rights reserved.
+"""
+
+from rktl_autonomy import RocketLeagueInterface
+import numpy as np
+from stable_baselines3 import PPO
+
+from stable_baselines3.common.vec_env import SubprocVecEnv
+from stable_baselines3.common.env_util import make_vec_env
+
+import uuid
+import optuna
+import sys
+
+from stable_baselines3.common.vec_env import VecCheckNan
+
+
+run_id = str(uuid.uuid4())  # ALL running environments must share this
+step = 0
+study = optuna.create_study()
+
+def optimize_ppo2(trial):
+    """ Learning hyperparamters we want to optimise"""
+    return {
+        'n_steps': int(trial.suggest_loguniform('n_steps', 16, 2048)),
+        'gamma': trial.suggest_loguniform('gamma', 0.9, 0.9997),
+        'learning_rate': trial.suggest_loguniform('learning_rate', 5e-6, 0.003), 
+        'ent_coef': trial.suggest_loguniform('ent_coef', 1e-8, 0.01), 
+        'clip_range': trial.suggest_uniform('clip_range', 0.1, 0.3), # try 0.2 and 0.3 as well
+        'n_epochs': int(trial.suggest_loguniform('n_epochs', 3, 30)),
+        'gae_lambda': trial.suggest_uniform('gae_lambda', 0.9, 1.0),
+        'batch_size': int(trial.suggest_uniform('batch_size', 4, 4096)),
+        'vf_coef': trial.suggest_uniform('v_coef', 0.5, 1.0)
+        #'max_grad_norm': trial.suggest_uniform('max_grad_norm', 0.9, 1.0)  
+    }
+
+
+def optimize_agent(trial):
+    
+    global step
+    global study
+    
+    env_count = 1 # Number of environments to run in parallel (keep at 1 for now)
+    timesteps = 2000 # Timesteps that the model will train on before getting assessed and tuned
+    episodes_per_trial = 7 # Number of episode attempts (runs) per trial
+    
+    ### Train the model and optimize it.
+    
+    # Hyperparams are determined by Optuna.
+    model_params = optimize_ppo2(trial)
+    
+    env = make_vec_env(RocketLeagueInterface, env_kwargs={'run_id' : run_id, 'launch_args': ['render:=false', 'plot_log:=false']},
+            n_envs= env_count , vec_env_cls=SubprocVecEnv) # Creates the env
+            
+    env = VecCheckNan(env, raise_exception=True)
+    
+    model = PPO("MlpPolicy", env, **model_params) # Creates the PPO network model based on the env and the provided hyperparameters.
+    
+    model.learn(timesteps) # Makes the model learn before getting assessed and tuned
+    
+    rewards = [] # The way the car was rewarded for each attempt it had in this tuning trial
+    
+    n_episodes, reward_sum = 0, 0.0
+
+    obs = env.reset()
+    while n_episodes < episodes_per_trial:
+    
+        if np.isnan(obs).any():
+            print("Best Params:" + str(study.best_params))
+            #print("\n\n OBS IS NAN\n\n")
+            sys.exit("OBS is NAN")
+  
+        action, _ = model.predict(obs)
+               
+        if np.isnan(action).any():
+            print("Best Params:" + str(study.best_params))
+            #print("\n\n ACTION IS NAN\n\n")
+            sys.exit("ACTION IS NAN")
+               
+        obs, reward, done, _ = env.step(action)
+        
+        
+        
+        reward_sum += reward
+
+        if done:
+            rewards.append(reward_sum)
+            reward_sum = 0.0
+            n_episodes += 1
+            obs = env.reset()
+
+    mean_reward = np.mean(rewards)
+    
+    step += 1
+    
+    print("\n")
+    print("Mean Reward at step #" + str(step) + " : " + str(mean_reward) )
+    if (step + 1) % 2 == 0 :
+        print("Best Params:" + str(study.best_params))
+
+    env.close() # this must be done to clean up other processes
+    
+    # Optuna maximizes negative reward, so we need to negate the reward here
+    trial.report(-1 * mean_reward, step)
+    
+    return -1 * mean_reward
+    
+    
+
+
+
+if __name__ == '__main__':      # this is required due to forking processes
+    #study = optuna.create_study()
+    
+    try:
+        study.optimize(optimize_agent, n_trials=10000, n_jobs=24)
+        print("\n")
+        print("Best Params:" + str(study.best_params))
+    except KeyboardInterrupt:
+        print('Interrupted by keyboard.')
+        print("\n")
+        print("Best Params:" + str(study.best_params))
+    
+    

--- a/rktl_autonomy/scripts/tune_rocket_league.py
+++ b/rktl_autonomy/scripts/tune_rocket_league.py
@@ -102,7 +102,7 @@ def optimize_agent(trial):
     
     print("\n")
     print("Mean Reward at step #" + str(step) + " : " + str(mean_reward) )
-    if (step + 1) % 2 == 0 :
+    if (step + 1) % 5 == 0 :
         print("Best Params:" + str(study.best_params))
 
     env.close() # this must be done to clean up other processes


### PR DESCRIPTION
Contains the hyperparameter tuning file `tune_rocket_league.py.`
README has been updated with instructions on how to run it / what it is.
Added **Optuna** to list of python imports in dockerfile.

To test, run the file as an executable!

NOTE: You will have to manually do `pip install optuna` before running the file if you do not update the docker container.

Success conditions:
  Will start by creating 24 environments (by default). You should be able to tell by the command window output.
  **Does not crash.** (at least not in the first 10 minutes).
  Prints something along these lines a few minutes after the 24 envs have been created:

```[I 2022-04-03 20:54:59,803] Trial 12 finished with value: 3461.1747444804305 and parameters: {'n_steps': 99.29606026326555, 'gamma': 0.988610907824562, 'learning_rate': 7.32803156090773e-05, 'ent_coef': 0.0012379069563492116, 'clip_range': 0.17999811186890116, 'n_epochs': 11.829678374733993, 'gae_lambda': 0.9869665011414711, 'batch_size': 3068.5267518223973, 'v_coef': 0.842153946924706}. Best is trial 19 with value: -3716.0103893711553.```

and

```Mean Reward at step #5 : -2805.640042650008 Best Params:{'n_steps': 175.59020170145627, 'gamma': 0.9468796287801651, 'learning_rate': 5.703090910618035e-06, 'ent_coef': 1.2657705119406923e-07, 'clip_range': 0.11669933937088449, 'n_epochs': 17.81494413459372, 'gae_lambda': 0.9642572738674232, 'batch_size': 2197.2385387190766, 'v_coef': 0.7188227643461709}```