### PR TITLE
Ai integration

### DIFF
--- a/rktl_autonomy/src/rktl_autonomy/rocket_league_interface.py
+++ b/rktl_autonomy/src/rktl_autonomy/rocket_league_interface.py
@@ -97,7 +97,7 @@ class RocketLeagueInterface(ROSInterface):
         rospy.Subscriber('match_status', MatchStatus, self._score_cb)
 
         # block until environment is ready
-        if eval:
+        if not eval:
             rospy.wait_for_service('sim_reset')
 
     @property


### PR DESCRIPTION
This allows us to run AI models on the actual hardware. Blocking on 'sim_reset` existing is clearly wrong when evaluating models, as it is only needed for training, and it won't exist in real life.

Coercing the observation is necessary since it won't calculate a new output until it receives valid input. This essentially sticks it in an "infinite loop"