### PR TITLE
add delay mux

### DIFF
--- a/rktl_control/launch/xbox_control.launch
+++ b/rktl_control/launch/xbox_control.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="device" default="/dev/input/js0"/>
     <arg name="car_name" default="car0" />
-    <arg name="delay" default="0" />
+    <arg name="delay" default="0.1" />
 
     <group ns="cars/$(arg car_name)">
         <!--  joystick driver -->
@@ -16,10 +16,17 @@
             <param name="boost_throttle" value="1.25"/>
             <param name="cooldown_ratio" value="3"/>
             <param name="max_boost" value="2"/>
+            <remap from="joy" to="joy_mux"/>
         </node>
+
         <!-- delay -->
         <node pkg="rktl_control" type="topic_delay" name="controller_delay"
-        args="joy joy_delayed
-        sensor_msgs/Joy $(arg delay)"/>
+            args="joy joy_delayed sensor_msgs/Joy $(arg delay)"/>
+
+        <!-- mux (no delay by default)-->
+        <node pkg="topic_tools" type="mux" name="controller_delay_mux"
+            args="joy_mux joy joy_delayed">
+            <remap from="mux" to="controller_delay_mux"/>
+        </node>
     </group>
 </launch>

--- a/rktl_control/nodes/xbox_interface
+++ b/rktl_control/nodes/xbox_interface
@@ -26,7 +26,7 @@ class XboxInterface():
         self.effort_pub = rospy.Publisher('effort', ControlEffort, queue_size=1)
 
         # Subscribers
-        rospy.Subscriber('joy_delayed', Joy, self.callback)
+        rospy.Subscriber('joy', Joy, self.callback)
 
         # Services
         self.reset_srv = rospy.ServiceProxy('/sim_reset', Empty)

--- a/rktl_control/package.xml
+++ b/rktl_control/package.xml
@@ -20,4 +20,5 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosserial_arduino</exec_depend>
   <exec_depend>joy</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 </package>

--- a/rktl_launch/rqt/rktl.perspective
+++ b/rktl_launch/rqt/rktl.perspective
@@ -4,14 +4,14 @@
     "mainwindow": {
       "keys": {
         "geometry": {
-          "repr(QByteArray.hex)": "QtCore.QByteArray(b'01d9d0cb000300000000006400000064000002cf000002dd0000006400000089000002cf000002dd000000000000000007800000006400000089000002cf000002dd')",
+          "repr(QByteArray.hex)": "QtCore.QByteArray(b'01d9d0cb000300000000017b0000001c000006c6000002d7000001a100000057000006a0000002b100000000000000000780000001a100000057000006a0000002b1')",
           "type": "repr(QByteArray.hex)",
-          "pretty-print": "     d d     d            d      "
+          "pretty-print": "     {         W            W    "
         },
         "state": {
-          "repr(QByteArray.hex)": "QtCore.QByteArray(b'000000ff00000000fd00000001000000030000026c0000022bfc0100000001fb00000058007200710074005f007000750062006c00690073006800650072005f005f005000750062006c00690073006800650072005f005f0031005f005f005000750062006c0069007300680065007200570069006400670065007401000000000000026c0000023000ffffff0000026c0000000000000004000000040000000800000008fc00000001000000030000000100000036004d0069006e0069006d0069007a006500640044006f0063006b00570069006400670065007400730054006f006f006c0062006100720000000000ffffffff0000000000000000')",
+          "repr(QByteArray.hex)": "QtCore.QByteArray(b'000000ff00000000fd00000001000000030000050000000231fc0100000002fc00000000000002a40000023000fffffffc0200000002fb00000058007200710074005f007000750062006c00690073006800650072005f005f005000750062006c00690073006800650072005f005f0031005f005f005000750062006c006900730068006500720057006900640067006500740100000014000001070000008a00fffffffb00000072007200710074005f0073006500720076006900630065005f00630061006c006c00650072005f005f005300650072007600690063006500430061006c006c00650072005f005f0031005f005f005300650072007600690063006500430061006c006c00650072005700690064006700650074010000012100000124000000fe00fffffffb0000005a007200710074005f0069006d006100670065005f0076006900650077005f005f0049006d0061006700650056006900650077005f005f0031005f005f0049006d006100670065005600690065007700570069006400670065007401000002aa00000256000000bf00ffffff000005000000000000000004000000040000000800000008fc00000001000000030000000100000036004d0069006e0069006d0069007a006500640044006f0063006b00570069006400670065007400730054006f006f006c0062006100720000000000ffffffff0000000000000000')",
           "type": "repr(QByteArray.hex)",
-          "pretty-print": "                 Xrqt_publisher__Publisher__1__PublisherWidget                            6MinimizedDockWidgetsToolbar        "
+          "pretty-print": "                     0                                                                                                                         ! $                                                       V                                                            "
         }
       },
       "groups": {
@@ -29,11 +29,78 @@
     "pluginmanager": {
       "keys": {
         "running-plugins": {
-          "repr": "{'rqt_publisher/Publisher': [1]}",
+          "repr": "{'rqt_image_view/ImageView': [1], 'rqt_publisher/Publisher': [1], 'rqt_service_caller/ServiceCaller': [1]}",
           "type": "repr"
         }
       },
       "groups": {
+        "plugin__rqt_image_view__ImageView__1": {
+          "keys": {},
+          "groups": {
+            "dock_widget__ImageViewWidget": {
+              "keys": {
+                "dock_widget_title": {
+                  "repr": "'Image View'",
+                  "type": "repr"
+                },
+                "dockable": {
+                  "repr": "True",
+                  "type": "repr"
+                },
+                "parent": {
+                  "repr": "None",
+                  "type": "repr"
+                }
+              },
+              "groups": {}
+            },
+            "plugin": {
+              "keys": {
+                "dynamic_range": {
+                  "repr": "False",
+                  "type": "repr"
+                },
+                "max_range": {
+                  "repr": "10.0",
+                  "type": "repr"
+                },
+                "mouse_pub_topic": {
+                  "repr": "'/cams/cam0/image_raw_mouse_left'",
+                  "type": "repr"
+                },
+                "num_gridlines": {
+                  "repr": "0",
+                  "type": "repr"
+                },
+                "publish_click_location": {
+                  "repr": "False",
+                  "type": "repr"
+                },
+                "rotate": {
+                  "repr": "0",
+                  "type": "repr"
+                },
+                "smooth_image": {
+                  "repr": "False",
+                  "type": "repr"
+                },
+                "toolbar_hidden": {
+                  "repr": "False",
+                  "type": "repr"
+                },
+                "topic": {
+                  "repr": "'/cams/cam0/image_raw'",
+                  "type": "repr"
+                },
+                "zoom1": {
+                  "repr": "False",
+                  "type": "repr"
+                }
+              },
+              "groups": {}
+            }
+          }
+        },
         "plugin__rqt_publisher__Publisher__1": {
           "keys": {},
           "groups": {
@@ -57,7 +124,42 @@
             "plugin": {
               "keys": {
                 "publishers": {
-                  "repr": "\"[{'topic_name': '/cars/enable', 'type_name': 'std_msgs/Bool', 'rate': 10.0, 'enabled': False, 'publisher_id': 0, 'counter': 86, 'expressions': {'/cars/enable/data': 'False'}}, {'topic_name': '/match_status', 'type_name': 'rktl_msgs/MatchStatus', 'rate': 20.0, 'enabled': False, 'publisher_id': 1, 'counter': 193, 'expressions': {}}]\"",
+                  "repr": "\"[{'topic_name': '/cars/enable', 'type_name': 'std_msgs/Bool', 'rate': 10.0, 'enabled': False, 'publisher_id': 0, 'counter': 9501, 'expressions': {'/cars/enable/data': 'False'}}, {'topic_name': '/match_status', 'type_name': 'rktl_msgs/MatchStatus', 'rate': 20.0, 'enabled': False, 'publisher_id': 1, 'counter': 0, 'expressions': {}}]\"",
+                  "type": "repr"
+                }
+              },
+              "groups": {}
+            }
+          }
+        },
+        "plugin__rqt_service_caller__ServiceCaller__1": {
+          "keys": {},
+          "groups": {
+            "dock_widget__ServiceCallerWidget": {
+              "keys": {
+                "dock_widget_title": {
+                  "repr": "'Service Caller'",
+                  "type": "repr"
+                },
+                "dockable": {
+                  "repr": "True",
+                  "type": "repr"
+                },
+                "parent": {
+                  "repr": "None",
+                  "type": "repr"
+                }
+              },
+              "groups": {}
+            },
+            "plugin": {
+              "keys": {
+                "current_service_name": {
+                  "repr": "'/cars/car1/controller_delay_mux/select'",
+                  "type": "repr"
+                },
+                "splitter_orientation": {
+                  "repr": "2",
                   "type": "repr"
                 }
               },


### PR DESCRIPTION
You can now toggle between delayed and non-delayed joystick signals using a mux. This is integrated into the rqt dashboard we have for simplicity. Call it with either `joy` or `joy_delayed` and it will appropriately delay or not delay their input.

![image](https://user-images.githubusercontent.com/15149822/165098649-f321d3d8-75f2-4245-88cc-788383164304.png)
