### PR TITLE
Time step config

### DIFF
--- a/rktl_sim/nodes/simulator
+++ b/rktl_sim/nodes/simulator
@@ -81,7 +81,7 @@ class SimulatorROS(object):
             self.check_urdf(path)
 
         # Creating physics simulator
-        self.sim = simulator.Sim(urdf_paths, field_setup, spawn_bounds, render_enabled)
+        self.sim = simulator.Sim(urdf_paths, field_setup, spawn_bounds, render_enabled, time_step)
 
         # Creating the ball
         ball_init_pose = rospy.get_param('~ball/init_pose', None)

--- a/rktl_sim/nodes/simulator
+++ b/rktl_sim/nodes/simulator
@@ -45,7 +45,11 @@ class SimulatorROS(object):
         rate = rospy.Rate(rospy.get_param('~rate', 30))
         self.frame_id = rospy.get_param('~frame_id', 'map')
         self.timeout = rospy.get_param('~timeout', 10)
-
+        
+        # Setting up physics
+        # Set time_step to a number less than 0 to not setTimeStep
+        time_step = rospy.get_param('~time_step', -1.0)
+        
         # Setting up field
         fw = rospy.get_param('/field/width')
         fl = rospy.get_param('/field/length')

--- a/rktl_sim/src/simulator/sim.py
+++ b/rktl_sim/src/simulator/sim.py
@@ -17,7 +17,7 @@ from simulator.car import Car
 class Sim(object):
     """Oversees components of the simulator"""
 
-    def __init__(self, urdf_paths, field_setup, spawn_bounds, render_enabled):
+    def __init__(self, urdf_paths, field_setup, spawn_bounds, render_enabled, time_step):
         if render_enabled:
             self._client = p.connect(p.GUI)
         else:

--- a/rktl_sim/src/simulator/sim.py
+++ b/rktl_sim/src/simulator/sim.py
@@ -112,6 +112,8 @@ class Sim(object):
 
         p.setPhysicsEngineParameter(useSplitImpulse=1, restitutionVelocityThreshold=0.0001)
         p.setGravity(0, 0, -10)
+        if time_step > 0.0:
+            p.setTimeStep(time_step)
 
     def create_ball(self, urdf_name, init_pose=None, init_speed=None, noise=None):
         if urdf_name in self.urdf_paths:


### PR DESCRIPTION
Adds a config option to use p.setTimeStep (off by default)  
I found this while looking for a way to slow down the simulation and watch movement more closely. However, since I don't have a very deep understanding of pybullet yet, I don't know if it messes with simulation outside of speed, so I left it off by default.  
0.001 is a good starting point if anyone is looking to test it.